### PR TITLE
Authenticate: List all affiliations of user

### DIFF
--- a/includes/Authenticate.php
+++ b/includes/Authenticate.php
@@ -154,6 +154,18 @@ class Authenticate
                 )
             ) {
                 $atts[$_key] = $value[0];
+	    } elseif (
+                is_array($value)
+                && in_array(
+                    $_key,
+                    [
+                        'eduPersonAffiliation',
+                        'eduPersonScopedAffiliation'
+                    ]
+                )
+            ) {
+                sort($value);
+                $atts[$_key] = implode(', ', $value);
             } else {
                 $atts[$key] = is_array($value) ? $value[0] : $value;
             }


### PR DESCRIPTION
Currently only a single random (?) affiliation is shown if multiple are available. This commit changes this to show all affiliations as a comma separated list.

Example: Two users with the affiliations "member" and "student"
Currently only one of the affiliations is shown for each user and it might differ for both users which of both affiliations is shown. With this commit "member, student" will be shown for both users.